### PR TITLE
nodejs instanceof array e2e test and fix

### DIFF
--- a/e2e/instanceof/__tests__/test.js
+++ b/e2e/instanceof/__tests__/test.js
@@ -9,8 +9,8 @@
 'use strict';
 
 const fs = require('fs');
-
 const http = require('http');
+const querystring = require('querystring');
 
 test('fs Error', () => {
   expect.hasAssertions();
@@ -25,7 +25,6 @@ test('fs Error', () => {
 test('http error', () =>
   new Promise((resolve, reject) => {
     const request = http.request('http://does-not-exist/blah', res => {
-      console.log(`STATUS: ${res.statusCode}`);
       res.on('end', () => {
         reject(new Error('Ended before failure'));
       });
@@ -41,6 +40,6 @@ test('http error', () =>
     });
   }));
 
-test('Array', () => {
-  expect([]).toBeInstanceOf(Array);
+test('querystring parse array', () => {
+  expect(querystring.parse('abc=xyz&abc=123').abc).toBeInstanceOf(Array);
 });

--- a/packages/jest-jasmine2/src/jasmine/Spec.js
+++ b/packages/jest-jasmine2/src/jasmine/Spec.js
@@ -31,6 +31,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /* @flow */
 /* eslint-disable sort-keys */
 
+import {AssertionError} from 'assert';
+
 import ExpectationFailed from '../ExpectationFailed';
 
 import expectationResultFactory from '../expectationResultFactory';
@@ -146,12 +148,12 @@ Spec.prototype.onException = function onException(error) {
     return;
   }
 
-  if (error && error.code === 'ERR_ASSERTION') {
-    error = assertionErrorMessage(error, {expand: this.expand});
-  }
-
   if (error instanceof ExpectationFailed) {
     return;
+  }
+
+  if (error instanceof AssertionError) {
+    error = assertionErrorMessage(error, {expand: this.expand});
   }
 
   this.addExpectationResult(

--- a/packages/jest-util/src/installCommonGlobals.js
+++ b/packages/jest-util/src/installCommonGlobals.js
@@ -67,6 +67,7 @@ export default function(globalObject: Global, globals: ConfigGlobals) {
   globalObject.setImmediate = global.setImmediate;
   globalObject.clearImmediate = global.clearImmediate;
 
+  addInstanceOfAlias(globalObject.Array, Array);
   addInstanceOfAlias(globalObject.Error, Error);
 
   return Object.assign(globalObject, deepCyclicCopy(globals));


### PR DESCRIPTION
## Summary
This is to contribute to the pull request #5995.

Added e2e test for `Array` `instanceof` error. I was able to reproduce this error locally with jest version `24.1.0` and `"testEnvironment": "node"` as reported in the original issue #2549. And verified this change against it and saw it working. 

I couldn't reproduce this issue in `"testEnvironment": "jsdom"`. And I couldn't fail the e2e tests against node version 6, 8, and 10 as well.
## Test plan
### Node version 6
```
node --version
v6.14.3
➜ pwd
/Users/chekkan/dev/facebook/jest/e2e/instanceof
➜ node ../../packages/jest-cli/bin/jest.js
 PASS  __tests__/test.js
  ✓ fs Error (5ms)
  ✓ http error (96ms)
  ✓ querystring parse array (1ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        1.051s
Ran all test suites.
```
### Node version 8
```
➜ node --version
v8.11.1
➜ pwd
/Users/chekkan/dev/facebook/jest/e2e/instanceof
➜ node ../../packages/jest-cli/bin/jest.js
 PASS  __tests__/test.js
  ✓ fs Error (4ms)
  ✓ http error (14ms)
  ✓ querystring parse array (3ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        0.798s
Ran all test suites.
```
### Node version 10
```
➜ node --version
v8.11.1
➜ pwd
/Users/chekkan/dev/facebook/jest/e2e/instanceof
➜ node ../../packages/jest-cli/bin/jest.js
 PASS  __tests__/test.js
  ✓ fs Error (4ms)
  ✓ http error (13ms)
  ✓ querystring parse array (1ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        0.763s
Ran all test suites.
```